### PR TITLE
feat: Refactor teams navigation to a dropdown menu

### DIFF
--- a/club.html
+++ b/club.html
@@ -16,14 +16,21 @@
     <header id="main-header">
         <div class="header-container">
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>

--- a/contacto.html
+++ b/contacto.html
@@ -16,14 +16,21 @@
     <header id="main-header">
         <div class="header-container">
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>

--- a/css/styles.css
+++ b/css/styles.css
@@ -155,6 +155,60 @@ img {
     width: 100%;
 }
 
+/* Dropdown Menu Styles */
+.nav-list .dropdown {
+    position: relative;
+}
+
+.nav-list .dropdown .dropdown-toggle::after {
+    content: ' ▾';
+    font-size: 0.8em;
+}
+
+.nav-list .dropdown .dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: var(--primary-color);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+    list-style: none;
+    padding: 0.5rem 0;
+    margin-top: 10px; /* Space between nav and dropdown */
+    min-width: 160px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    transition: opacity var(--transition-speed) ease, transform var(--transition-speed) ease;
+    z-index: 1001;
+}
+
+.nav-list .dropdown:hover .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.nav-list .dropdown .dropdown-menu li {
+    width: 100%;
+}
+
+.nav-list .dropdown .dropdown-menu a {
+    padding: 0.75rem 1.5rem;
+    display: block;
+    width: 100%;
+    text-align: left;
+}
+
+.nav-list .dropdown .dropdown-menu a::after {
+    display: none; /* Hide the underline effect from main nav items */
+}
+
+.nav-list .dropdown .dropdown-menu a:hover {
+    background-color: var(--primary-color-light);
+    color: var(--light-text-color);
+}
+
 .cart-link {
     position: relative;
     display: flex;
@@ -707,47 +761,62 @@ img {
 }
 
 /* ==========================================================================
-   12. INTERFAZ DE PESTAÑAS (EQUIPOS)
+   12. FILTROS Y EQUIPOS (PÁGINA DE EQUIPOS)
    ========================================================================== */
 .tabs-container {
     display: flex;
     justify-content: center;
-    gap: 1rem;
-    margin-bottom: 2rem;
+    flex-wrap: wrap; /* Permite que los botones pasen a la siguiente línea */
+    gap: 0.75rem; /* Espacio entre botones */
+    margin-bottom: 2.5rem;
 }
 
 .tab-button {
-    padding: 0.75rem 1.5rem;
-    font-size: 1.1rem;
+    padding: 0.6rem 1.2rem;
+    font-size: 0.95rem;
     font-weight: 600;
     background-color: var(--surface-color);
     color: var(--primary-color);
-    border: 2px solid var(--primary-color);
+    border: 1px solid var(--border-color);
     border-radius: 50px;
     cursor: pointer;
-    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease;
+    transition: all var(--transition-speed) ease;
 }
 
 .tab-button:hover {
     background-color: var(--primary-color-light);
     color: var(--light-text-color);
     border-color: var(--primary-color-light);
+    transform: translateY(-2px);
 }
 
 .tab-button.active {
     background-color: var(--primary-color);
     color: var(--light-text-color);
     border-color: var(--primary-color);
+    box-shadow: 0 4px 10px rgba(13, 44, 84, 0.3);
 }
 
-.tab-content {
-    display: none; /* Oculto por defecto */
+.team-entry {
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    margin-bottom: 2rem;
+    padding: 2rem;
+    box-shadow: var(--box-shadow);
+    animation: fadeIn 0.5s ease-in-out;
 }
 
-.tab-content.active {
-    display: block; /* Visible cuando está activo */
+.team-entry.hidden {
+    display: none;
 }
 
+.team-name {
+    font-size: 1.8rem;
+    color: var(--primary-color);
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 3px solid var(--accent-color);
+}
 
 /* ==========================================================================
    9. ACCESIBILIDAD
@@ -756,41 +825,6 @@ img {
 a:focus-visible, button:focus-visible {
     outline: 2px solid var(--accent-color);
     outline-offset: 2px;
-}
-
-/* ==========================================================================
-   13. DISEÑO DE ACORDEÓN (EQUIPOS)
-   ========================================================================== */
-.accordion {
-    background-color: var(--surface-color);
-    color: var(--primary-color);
-    cursor: pointer;
-    padding: 18px;
-    width: 100%;
-    border: 1px solid var(--border-color);
-    text-align: left;
-    outline: none;
-    font-size: 1.2rem;
-    font-weight: 700;
-    transition: 0.4s;
-    margin-top: 0.5rem;
-}
-
-.accordion:hover {
-    background-color: #f1f1f1;
-}
-
-.accordion.active {
-    background-color: var(--primary-color-light);
-    color: var(--light-text-color);
-}
-
-.panel {
-    padding: 0 18px;
-    background-color: white;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.2s ease-out;
 }
 
 .player-grid {
@@ -817,4 +851,123 @@ a:focus-visible, button:focus-visible {
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--text-color);
+}
+
+/* ==========================================================================
+   14. MAIN VIEW TABS (EQUIPOS PAGE)
+   ========================================================================== */
+.main-tabs-container {
+    display: flex;
+    justify-content: center;
+    border-bottom: 2px solid var(--border-color);
+    margin-bottom: 2rem;
+    padding: 0 !important; /* Override container padding */
+}
+
+.main-tab-button {
+    padding: 1rem 2rem;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--primary-color-light);
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    transition: all var(--transition-speed) ease;
+    border-bottom: 4px solid transparent;
+    margin-bottom: -2px; /* Align with the container's border */
+}
+
+.main-tab-button:hover {
+    background-color: rgba(13, 44, 84, 0.05);
+}
+
+.main-tab-button.active {
+    color: var(--primary-color);
+    border-bottom-color: var(--accent-color);
+}
+
+.view-content {
+    display: none;
+}
+
+.view-content.active {
+    display: block;
+    animation: fadeIn 0.5s ease-in-out; /* Reuse existing animation */
+}
+
+/* ==========================================================================
+   15. STAFF CARDS (ENTRENADORES PAGE)
+   ========================================================================== */
+.staff-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 2rem;
+}
+
+.staff-card {
+    position: relative;
+    background-color: var(--surface-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    text-align: center;
+    overflow: hidden; /* To keep the hover info contained */
+    transition: transform var(--transition-speed) ease;
+}
+
+.staff-card:hover {
+    transform: translateY(-5px);
+}
+
+.staff-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    object-position: top; /* Focus on the top of the image */
+}
+
+.staff-card h4 {
+    padding: 1rem;
+    font-size: 1.1rem;
+    color: var(--primary-color);
+}
+
+.staff-hover-info {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(13, 44, 84, 0.95); /* Semi-transparent overlay */
+    color: var(--light-text-color);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-speed) ease, visibility var(--transition-speed) ease;
+}
+
+.staff-card:hover .staff-hover-info {
+    opacity: 1;
+    visibility: visible;
+}
+
+.staff-hover-info h5 {
+    font-size: 1rem;
+    color: var(--accent-color);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+}
+
+.staff-hover-info ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.85rem;
+}
+
+.staff-hover-info li {
+    margin-bottom: 0.25rem;
 }

--- a/entrenadores.html
+++ b/entrenadores.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cuerpo Técnico - Club Deportivo Balonmano Barbate</title>
+    <meta name="description" content="Conoce a los entrenadores, oficiales y técnicos del Club Deportivo Balonmano Barbate.">
+    <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <header id="main-header">
+        <div class="header-container">
+            <a href="index.html" class="logo">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
+            </a>
+            <nav id="main-nav" aria-label="Menú principal">
+                <ul class="nav-list">
+                    <li><a href="club.html">Club</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="noticias.html">Noticias</a></li>
+                    <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
+                    <li><a href="contacto.html">Contacto</a></li>
+                </ul>
+            </nav>
+            <button id="hamburger-btn" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
+                <span class="hamburger-line"></span>
+                <span class="hamburger-line"></span>
+                <span class="hamburger-line"></span>
+            </button>
+        </div>
+    </header>
+
+    <main>
+        <section id="staff-list" class="container">
+            <h2>Cuerpo Técnico</h2>
+            <p style="text-align: center; margin-bottom: 2rem;">Conoce a los entrenadores, oficiales y técnicos que hacen posible nuestro club.</p>
+
+            <!-- Aquí irá el contenido de los técnicos de playa -->
+            <div id="beach-staff-section">
+                <h3>Técnicos de Playa</h3>
+                <div class="staff-grid">
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de JUAN JOSE CANALES CIFUENTES">
+                        <h4>JUAN JOSE CANALES CIFUENTES</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Oficial @ BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de ALBA MARIA TAMAYO MANZORRO">
+                        <h4>ALBA MARIA TAMAYO MANZORRO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Invitado @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de MARIA PERDIGONES RUBIO">
+                        <h4>MARIA PERDIGONES RUBIO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Invitado @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE">
+                        <h4>ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ BALONMANO BARBATE</li><li>Oficial @ SALAZONES LA CHANCA BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de ANTONIO MANUEL VALDES VIEGAS">
+                        <h4>ANTONIO MANUEL VALDES VIEGAS</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ BALONMANO BARBATE</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Entrenador @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BM BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER MANZORRO CRESPO">
+                        <h4>FRANCISCO JAVIER MANZORRO CRESPO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ BALONMANO BARBATE</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Entrenador @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER GUERRERO SUAREZ">
+                        <h4>FRANCISCO JAVIER GUERRERO SUAREZ</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ BALONMANO BARBATE</li><li>Oficial @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de JOSE GOMEZ LOPEZ">
+                        <h4>JOSE GOMEZ LOPEZ</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Entrenador @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de DIEGO GONZALEZ PICAZO">
+                        <h4>DIEGO GONZALEZ PICAZO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li><li>Oficial @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BM BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de JOSE MANUEL ARAGON JIMENEZ">
+                        <h4>JOSE MANUEL ARAGON JIMENEZ</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Entrenador @ BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de MARTIN PACHECO CAZORLA">
+                        <h4>MARTIN PACHECO CAZORLA</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE PROMESAS</li><li>Entrenador @ SALAZONES LA CHANCA BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de OSCAR PEREZ SEQUERA">
+                        <h4>OSCAR PEREZ SEQUERA</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Oficial @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de RICARDO CRESPO GALLARDO">
+                        <h4>RICARDO CRESPO GALLARDO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BM BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de ANTONIO JOSE RODRIGUEZ MALIA">
+                        <h4>ANTONIO JOSE RODRIGUEZ MALIA</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Entrenador @ BALONMANO BARBATE PROMESAS</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li><li>Staff Adicional @ BALONMANO BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de MANUEL JESUS UTRERA TIRADO">
+                        <h4>MANUEL JESUS UTRERA TIRADO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Oficial @ BALONMANO BARBATE PROMESAS</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de DIEGO RELINQUE LEMOS">
+                        <h4>DIEGO RELINQUE LEMOS</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de TOMAS JESUS RAMIREZ TIRADO">
+                        <h4>TOMAS JESUS RAMIREZ TIRADO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li><li>Entrenador @ BM BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de PEDRO MORENO CALLADO">
+                        <h4>PEDRO MORENO CALLADO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Entrenador @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ SALAZONES LA CHANCA BM BARBATE</li></ul></div>
+                    </div>
+                    <div class="staff-card">
+                        <img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO GUERRERO VARO">
+                        <h4>ALEJANDRO GUERRERO VARO</h4>
+                        <div class="staff-hover-info"><h5>Equipos y Roles</h5><ul><li>Staff Adicional @ BALONMANO BARBATE CAD FEM PROM</li><li>Staff Adicional @ LA CHANCA BALONMANO BARBATE</li><li>Staff Adicional @ SALAZONES LA CHANCA BALONMANO BARBATE</li></ul></div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="pista-staff-section" style="margin-top: 4rem;">
+                <h3>Técnicos de Pista</h3>
+                <p>La información sobre el cuerpo técnico de los equipos de pista no está disponible actualmente.</p>
+            </div>
+        </section>
+    </main>
+
+    <footer id="main-footer">
+        <div class="footer-content container">
+            <div class="footer-section about">
+                <h4>Sobre el Club</h4>
+                <p>Fomentando el balonmano en Barbate. Somos más que un club, somos una familia unida por la pasión por este deporte.</p>
+                <div class="sponsors">
+                    <img src="https://via.placeholder.com/100x40/ffffff/000000?text=Sponsor+1" alt="Logo Patrocinador 1">
+                    <img src="https://via.placeholder.com/100x40/ffffff/000000?text=Sponsor+2" alt="Logo Patrocinador 2">
+                    <img src="https://via.placeholder.com/100x40/ffffff/000000?text=Sponsor+3" alt="Logo Patrocinador 3">
+                </div>
+            </div>
+            <div class="footer-section links">
+                <h4>Enlaces Rápidos</h4>
+                <ul>
+                    <li><a href="club.html">Club</a></li>
+                    <li><a href="equipos.html">Equipos</a></li>
+                    <li><a href="noticias.html">Noticias</a></li>
+                    <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="contacto.html">Contacto</a></li>
+                </ul>
+            </div>
+            <div class="footer-section contact">
+                <h4>Contacto</h4>
+                <p><i class="icon-map-pin"></i> Pabellón Municipal de Barbate</p>
+                <p><i class="icon-mail"></i> <a href="mailto:balonmanobarbate@gmail.com">balonmanobarbate@gmail.com</a></p>
+                <p><i class="icon-phone"></i> (Teléfono no disponible)</p>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Club Deportivo Balonmano Barbate. Todos los derechos reservados.</p>
+        </div>
+    </footer>
+
+    <div id="cookie-banner">
+        <p>Este sitio web utiliza cookies para mejorar tu experiencia. Al continuar, aceptas nuestro uso de cookies.</p>
+        <div class="cookie-buttons">
+            <button id="cookie-accept-btn">Aceptar</button>
+            <button id="cookie-reject-btn">Rechazar</button>
+            <a href="#" class="cookie-info-link">Más info</a>
+        </div>
+    </div>
+
+    <script src="js/script.js"></script>
+
+</body>
+</html>

--- a/equipos.html
+++ b/equipos.html
@@ -16,14 +16,21 @@
     <header id="main-header">
         <div class="header-container">
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>
@@ -36,177 +43,422 @@
     </header>
 
     <main>
-        <section id="teams-list" class="container">
-            <h2>Nuestros Equipos de Pista</h2>
-            <p style="text-align: center; margin-bottom: 2rem;">Haz clic en una categoría para desplegar la plantilla de jugadores.</p>
+        <div id="pista-view" class="view-content active">
+            <section id="teams-list" class="container">
+                <h2>Nuestros Equipos de Pista</h2>
+                <p style="text-align: center; margin-bottom: 2rem;">Filtra por categoría para ver los equipos y sus jugadores.</p>
 
-            <!-- Senior Masculino -->
-            <button class="accordion">Senior Masculino</button>
-            <div class="panel">
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AARON MEDINA BARRERA"><h4>AARON MEDINA BARRERA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ADRIAN CHAMORRO POZO"><h4>ADRIAN CHAMORRO POZO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE"><h4>ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALVARO BLANCO DENIA"><h4>ALVARO BLANCO DENIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CRISTIAN RAMIREZ VELA"><h4>CRISTIAN RAMIREZ VELA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DAVID MUÑOZ RUIZ"><h4>DAVID MUÑOZ RUIZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DIEGO GONZALEZ PICAZO"><h4>DIEGO GONZALEZ PICAZO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO VIDAL MATEO"><h4>FRANCISCO VIDAL MATEO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER MANZORRO CRESPO"><h4>FRANCISCO JAVIER MANZORRO CRESPO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER GUERRERO SUAREZ"><h4>FRANCISCO JAVIER GUERRERO SUAREZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO MANUEL CLA MARTINEZ"><h4>FRANCISCO MANUEL CLA MARTINEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GOMEZ LOPEZ"><h4>JOSE GOMEZ LOPEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE DAVILA ROBLE"><h4>JOSE DAVILA ROBLE</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN ANTONIO DOMINGUEZ MORENO"><h4>JUAN ANTONIO DOMINGUEZ MORENO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN JOSE CANALES CIFUENTES"><h4>JUAN JOSE CANALES CIFUENTES</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN RAMON MERA DOMINGUEZ"><h4>JUAN RAMON MERA DOMINGUEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO CARO RELINQUE"><h4>PABLO CARO RELINQUE</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PEDRO MORENO CALLADO"><h4>PEDRO MORENO CALLADO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SEBASTIAN CANALES CIFUENTES"><h4>SEBASTIAN CANALES CIFUENTES</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SEBASTIAN CARDOSO TRAUCA"><h4>SEBASTIAN CARDOSO TRAUCA</h4></div>
-                </div>
-            </div>
-
-            <!-- Juvenil Masculino -->
-            <button class="accordion">Juvenil Masculino</button>
-            <div class="panel">
-                <p>Información de la plantilla próximamente.</p>
-            </div>
-
-            <!-- Cadete Masculino -->
-            <button class="accordion">Cadete Masculino</button>
-            <div class="panel">
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO NUÑEZ CARAMAZANA"><h4>ALEJANDRO NUÑEZ CARAMAZANA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO MEDINA BARRERA"><h4>ALEJANDRO MEDINA BARRERA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALI VERSACI DIAZ"><h4>ALI VERSACI DIAZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALONSO OLIVA SANCHEZ"><h4>ALONSO OLIVA SANCHEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALVARO RAMIREZ PAREJA"><h4>ALVARO RAMIREZ PAREJA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ANTONIO CHAMORRO ALBA"><h4>ANTONIO CHAMORRO ALBA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO MEDINA BARRERA"><h4>DARIO MEDINA BARRERA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL GRAÑA SOUZA"><h4>EZEQUIEL GRAÑA SOUZA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ALBERTO GOMEZ DOMINGUEZ"><h4>JOSE ALBERTO GOMEZ DOMINGUEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ANGEL POZO NARVAEZ"><h4>JOSE ANGEL POZO NARVAEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ANTONIO VIDAL MATEO"><h4>JOSE ANTONIO VIDAL MATEO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE MANUEL PAREJA DAVILA"><h4>JOSE MANUEL PAREJA DAVILA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL ANTONIO RELINQUE CAMACHO"><h4>MANUEL ANTONIO RELINQUE CAMACHO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PEDRO LARA OLIVA"><h4>PEDRO LARA OLIVA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON DEL POZO ROSSI"><h4>RAMON DEL POZO ROSSI</h4></div>
-                </div>
-            </div>
-
-            <!-- Cadete Femenino -->
-            <button class="accordion">Cadete Femenino</button>
-            <div class="panel">
-                <h5>Equipo: LA CHANCA BALONMANO BARBATE</h5>
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLOTA RIVERA MALIA"><h4>CARLOTA RIVERA MALIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GIL GILIBERT"><h4>CARMEN GIL GILIBERT</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA GONZALEZ RUIZ-BERDEJO"><h4>DANIELA GONZALEZ RUIZ-BERDEJO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA JUNQUERA JIMENEZ"><h4>JULIA JUNQUERA JIMENEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA TAMAYO MANZORRO"><h4>LUCIA TAMAYO MANZORRO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MAIA GONZALEZ UREBA"><h4>MAIA GONZALEZ UREBA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA RAMOS CHIRINO"><h4>MARIA RAMOS CHIRINO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO CABALLERO"><h4>MARIA VARO CABALLERO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIRIAM GONZALEZ TAMAYO"><h4>MIRIAM GONZALEZ TAMAYO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NORA DIEGO VENEGAS"><h4>NORA DIEGO VENEGAS</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAOLA CORRALES VARO"><h4>PAOLA CORRALES VARO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA BELTRAN RIVERA"><h4>PAULA BELTRAN RIVERA</h4></div>
-                </div>
-                <h5 style="margin-top: 1.5rem;">Equipo: BALONMANO BARBATE PROMESAS</h5>
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRA GONZALEZ MALIA"><h4>ALEJANDRA GONZALEZ MALIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CARO RELINQUE"><h4>CARMEN CARO RELINQUE</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GONZALEZ PICAZO"><h4>CARMEN GONZALEZ PICAZO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN MALIA CRESPO"><h4>CARMEN MALIA CRESPO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CELIA BLANCO DENIA"><h4>CELIA BLANCO DENIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA CORTEJOSA VARO"><h4>DANIELA CORTEJOSA VARO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA AREVALO RIVERA"><h4>ELENA AREVALO RIVERA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EVA TIRADO CLA"><h4>EVA TIRADO CLA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GEMA GUZMAN AMBITE"><h4>GEMA GUZMAN AMBITE</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA ALBA CORTEJOSA"><h4>LUCIA ALBA CORTEJOSA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA RUBIO POZO"><h4>LUCIA RUBIO POZO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PATRICIA MALIA JODAR"><h4>PATRICIA MALIA JODAR</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MONCAYO RODRIGUEZ"><h4>PAULA MONCAYO RODRIGUEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSARIO LOPEZ NUÑEZ"><h4>ROSARIO LOPEZ NUÑEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SOFIA BRAVO GRAÑA"><h4>SOFIA BRAVO GRAÑA</h4></div>
-                </div>
-            </div>
-
-            <!-- Infantil Masculino -->
-            <button class="accordion">Infantil Masculino</button>
-            <div class="panel">
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO GILABERT ROMERO"><h4>DARIO GILABERT ROMERO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL LEWERENZ LOSADA"><h4>EZEQUIEL LEWERENZ LOSADA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER SANCHEZ CANTILLO"><h4>FRANCISCO JAVIER SANCHEZ CANTILLO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JOSE MUÑOZ ALONSO"><h4>FRANCISCO JOSE MUÑOZ ALONSO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GONZALO GUTIERREZ RUIZ"><h4>GONZALO GUTIERREZ RUIZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JAVIER ALCEDO GONZALEZ"><h4>JAVIER ALCEDO GONZALEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GIL PACHECO"><h4>JOSE GIL PACHECO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE DIEGO BASALLOTE MARTIN"><h4>JOSE DIEGO BASALLOTE MARTIN</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL VALDES CANTILLO"><h4>MANUEL VALDES CANTILLO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL JESUS UTRERA GARCIA"><h4>MANUEL JESUS UTRERA GARCIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIGUEL QUIROS PAREJA"><h4>MIGUEL QUIROS PAREJA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO RODRIGUEZ MORENO"><h4>PABLO RODRIGUEZ MORENO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO JIMENEZ RAMOS"><h4>PABLO JIMENEZ RAMOS</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON MORILLO SANCHEZ"><h4>RAMON MORILLO SANCHEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RODRIGO ROSADO GONZALEZ"><h4>RODRIGO ROSADO GONZALEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TOMAS RAMIREZ JIMENEZ"><h4>TOMAS RAMIREZ JIMENEZ</h4></div>
-                </div>
-            </div>
-
-            <!-- Infantil Femenino -->
-            <button class="accordion">Infantil Femenino</button>
-            <div class="panel">
-                <h5>Equipo: LA CHANCA BALONMANO BARBATE</h5>
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AFRICA DE LA ROSA ALVARADO"><h4>AFRICA DE LA ROSA ALVARADO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AISHA VARO DIOUCK"><h4>AISHA VARO DIOUCK</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALICIA MUÑOZ LOPEZ"><h4>ALICIA MUÑOZ LOPEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN BERNAL GARCIA"><h4>CARMEN BERNAL GARCIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CLAUDIA TIRADO RIVERA"><h4>CLAUDIA TIRADO RIVERA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA VARO BERNAL"><h4>ELENA VARO BERNAL</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FATIMA CARAVACA BERNAL"><h4>FATIMA CARAVACA BERNAL</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCESCA CROCI ORTEGA"><h4>FRANCESCA CROCI ORTEGA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LOLA CID OLIVA"><h4>LOLA CID OLIVA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO MUÑOZ"><h4>MARIA VARO MUÑOZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA ANTONIA DE LA CRUZ LIGERO"><h4>MARIA ANTONIA DE LA CRUZ LIGERO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA JESUS OLIVA CORRALES"><h4>MARIA JESUS OLIVA CORRALES</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NATALIA VALDES BRAZA"><h4>NATALIA VALDES BRAZA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSA GOMEZ DOMINGUEZ"><h4>ROSA GOMEZ DOMINGUEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SARA FERNANDEZ BERNAL"><h4>SARA FERNANDEZ BERNAL</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TERE SANCHEZ BERNAL"><h4>TERE SANCHEZ BERNAL</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de VALERIA YOLANDA GARCIA MARQUEZ"><h4>VALERIA YOLANDA GARCIA MARQUEZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ZAMARA NAVARRO RODRIGUEZ"><h4>ZAMARA NAVARRO RODRIGUEZ</h4></div>
-                </div>
-                <h5 style="margin-top: 1.5rem;">Equipo: BALONMANO BARBATE PROMESAS</h5>
-                <div class="player-grid">
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AMAIA GIL MARIN"><h4>AMAIA GIL MARIN</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ARANTXA DE GOMAR LARA"><h4>ARANTXA DE GOMAR LARA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA RODRIGUEZ CASTILLO"><h4>CARLA RODRIGUEZ CASTILLO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA GONZALEZ SANTIAGO"><h4>CARLA GONZALEZ SANTIAGO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN BARRIENTOS GALINDO"><h4>CARMEN BARRIENTOS GALINDO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CORRALES VARO"><h4>CARMEN CORRALES VARO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CRISTINA SANCHEZ BEZA"><h4>CRISTINA SANCHEZ BEZA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de IDAYRA ANGULO AGUILAR"><h4>IDAYRA ANGULO AGUILAR</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA VELAZQUEZ GARCIA"><h4>JULIA VELAZQUEZ GARCIA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LARA LOPEZ VILADOMS"><h4>LARA LOPEZ VILADOMS</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LAURA VARO BRENES"><h4>LAURA VARO BRENES</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA HEREDIA MUÑOZ"><h4>LUCIA HEREDIA MUÑOZ</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA MORON TRUJILLO"><h4>LUCIA MORON TRUJILLO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARGARITA MARQUEZ HORCAJADAS"><h4>MARGARITA MARQUEZ HORCAJADAS</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA GUERRERO ALCEDO"><h4>MARIA GUERRERO ALCEDO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA DANIELA MELENDEZ TIRADO"><h4>MARIA DANIELA MELENDEZ TIRADO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIAM GUTIERREZ -RAVE TIRADO"><h4>MARIAM GUTIERREZ -RAVE TIRADO</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA PEREZ REVUELTA"><h4>MARTA PEREZ REVUELTA</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA MALIA RENDON"><h4>MARTA MALIA RENDON</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA ARAGON BARRIENTOS"><h4>PAULA ARAGON BARRIENTOS</h4></div>
-                    <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MORENO MEDINA"><h4>PAULA MORENO MEDINA</h4></div>
+                <!-- Contenedor de Filtros -->
+                <div id="team-filters" class="tabs-container">
+                    <button class="tab-button active" data-category="all">Todos</button>
+                    <button class="tab-button" data-category="senior-masculino">Senior Masculino</button>
+                    <button class="tab-button" data-category="juvenil-masculino">Juvenil Masculino</button>
+                    <button class="tab-button" data-category="cadete-masculino">Cadete Masculino</button>
+                    <button class="tab-button" data-category="cadete-femenino">Cadete Femenino</button>
+                    <button class="tab-button" data-category="infantil-masculino">Infantil Masculino</button>
+                    <button class="tab-button" data-category="infantil-femenino">Infantil Femenino</button>
                 </div>
 
-            </div>
+                <!-- Contenedor de Equipos -->
+                <div id="teams-container">
+                    <!-- Senior Masculino -->
+                    <div class="team-entry" data-category="senior-masculino">
+                        <h3 class="team-name">Senior Masculino</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AARON MEDINA BARRERA"><h4>AARON MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ADRIAN CHAMORRO POZO"><h4>ADRIAN CHAMORRO POZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE"><h4>ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALVARO BLANCO DENIA"><h4>ALVARO BLANCO DENIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CRISTIAN RAMIREZ VELA"><h4>CRISTIAN RAMIREZ VELA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DAVID MUÑOZ RUIZ"><h4>DAVID MUÑOZ RUIZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DIEGO GONZALEZ PICAZO"><h4>DIEGO GONZALEZ PICAZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO VIDAL MATEO"><h4>FRANCISCO VIDAL MATEO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER MANZORRO CRESPO"><h4>FRANCISCO JAVIER MANZORRO CRESPO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER GUERRERO SUAREZ"><h4>FRANCISCO JAVIER GUERRERO SUAREZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO MANUEL CLA MARTINEZ"><h4>FRANCISCO MANUEL CLA MARTINEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GOMEZ LOPEZ"><h4>JOSE GOMEZ LOPEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE DAVILA ROBLE"><h4>JOSE DAVILA ROBLE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN ANTONIO DOMINGUEZ MORENO"><h4>JUAN ANTONIO DOMINGUEZ MORENO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN JOSE CANALES CIFUENTES"><h4>JUAN JOSE CANALES CIFUENTES</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN RAMON MERA DOMINGUEZ"><h4>JUAN RAMON MERA DOMINGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO CARO RELINQUE"><h4>PABLO CARO RELINQUE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PEDRO MORENO CALLADO"><h4>PEDRO MORENO CALLADO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SEBASTIAN CANALES CIFUENTES"><h4>SEBASTIAN CANALES CIFUENTES</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SEBASTIAN CARDOSO TRAUCA"><h4>SEBASTIAN CARDOSO TRAUCA</h4></div>
+                        </div>
+                    </div>
 
+                    <!-- Juvenil Masculino -->
+                    <div class="team-entry" data-category="juvenil-masculino">
+                        <h3 class="team-name">Juvenil Masculino</h3>
+                        <p>Información de la plantilla próximamente.</p>
+                    </div>
+
+                    <!-- Cadete Masculino -->
+                    <div class="team-entry" data-category="cadete-masculino">
+                        <h3 class="team-name">Cadete Masculino</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO NUÑEZ CARAMAZANA"><h4>ALEJANDRO NUÑEZ CARAMAZANA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO MEDINA BARRERA"><h4>ALEJANDRO MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALI VERSACI DIAZ"><h4>ALI VERSACI DIAZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALONSO OLIVA SANCHEZ"><h4>ALONSO OLIVA SANCHEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALVARO RAMIREZ PAREJA"><h4>ALVARO RAMIREZ PAREJA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ANTONIO CHAMORRO ALBA"><h4>ANTONIO CHAMORRO ALBA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO MEDINA BARRERA"><h4>DARIO MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL GRAÑA SOUZA"><h4>EZEQUIEL GRAÑA SOUZA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ALBERTO GOMEZ DOMINGUEZ"><h4>JOSE ALBERTO GOMEZ DOMINGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ANGEL POZO NARVAEZ"><h4>JOSE ANGEL POZO NARVAEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ANTONIO VIDAL MATEO"><h4>JOSE ANTONIO VIDAL MATEO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE MANUEL PAREJA DAVILA"><h4>JOSE MANUEL PAREJA DAVILA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL ANTONIO RELINQUE CAMACHO"><h4>MANUEL ANTONIO RELINQUE CAMACHO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PEDRO LARA OLIVA"><h4>PEDRO LARA OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON DEL POZO ROSSI"><h4>RAMON DEL POZO ROSSI</h4></div>
+                        </div>
+                    </div>
+
+                    <!-- Cadete Femenino -->
+                    <div class="team-entry" data-category="cadete-femenino">
+                        <h3 class="team-name">Cadete Femenino</h3>
+                        <h5>Equipo: LA CHANCA BALONMANO BARBATE</h5>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLOTA RIVERA MALIA"><h4>CARLOTA RIVERA MALIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GIL GILIBERT"><h4>CARMEN GIL GILIBERT</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA GONZALEZ RUIZ-BERDEJO"><h4>DANIELA GONZALEZ RUIZ-BERDEJO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA JUNQUERA JIMENEZ"><h4>JULIA JUNQUERA JIMENEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA TAMAYO MANZORRO"><h4>LUCIA TAMAYO MANZORRO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MAIA GONZALEZ UREBA"><h4>MAIA GONZALEZ UREBA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA RAMOS CHIRINO"><h4>MARIA RAMOS CHIRINO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO CABALLERO"><h4>MARIA VARO CABALLERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIRIAM GONZALEZ TAMAYO"><h4>MIRIAM GONZALEZ TAMAYO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NORA DIEGO VENEGAS"><h4>NORA DIEGO VENEGAS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAOLA CORRALES VARO"><h4>PAOLA CORRALES VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA BELTRAN RIVERA"><h4>PAULA BELTRAN RIVERA</h4></div>
+                        </div>
+                        <h5 style="margin-top: 1.5rem;">Equipo: BALONMANO BARBATE PROMESAS</h5>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRA GONZALEZ MALIA"><h4>ALEJANDRA GONZALEZ MALIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CARO RELINQUE"><h4>CARMEN CARO RELINQUE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GONZALEZ PICAZO"><h4>CARMEN GONZALEZ PICAZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN MALIA CRESPO"><h4>CARMEN MALIA CRESPO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CELIA BLANCO DENIA"><h4>CELIA BLANCO DENIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA CORTEJOSA VARO"><h4>DANIELA CORTEJOSA VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA AREVALO RIVERA"><h4>ELENA AREVALO RIVERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EVA TIRADO CLA"><h4>EVA TIRADO CLA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GEMA GUZMAN AMBITE"><h4>GEMA GUZMAN AMBITE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA ALBA CORTEJOSA"><h4>LUCIA ALBA CORTEJOSA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA RUBIO POZO"><h4>LUCIA RUBIO POZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PATRICIA MALIA JODAR"><h4>PATRICIA MALIA JODAR</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MONCAYO RODRIGUEZ"><h4>PAULA MONCAYO RODRIGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSARIO LOPEZ NUÑEZ"><h4>ROSARIO LOPEZ NUÑEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SOFIA BRAVO GRAÑA"><h4>SOFIA BRAVO GRAÑA</h4></div>
+                        </div>
+                    </div>
+
+                    <!-- Infantil Masculino -->
+                    <div class="team-entry" data-category="infantil-masculino">
+                        <h3 class="team-name">Infantil Masculino</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO GILABERT ROMERO"><h4>DARIO GILABERT ROMERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL LEWERENZ LOSADA"><h4>EZEQUIEL LEWERENZ LOSADA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER SANCHEZ CANTILLO"><h4>FRANCISCO JAVIER SANCHEZ CANTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JOSE MUÑOZ ALONSO"><h4>FRANCISCO JOSE MUÑOZ ALONSO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GONZALO GUTIERREZ RUIZ"><h4>GONZALO GUTIERREZ RUIZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JAVIER ALCEDO GONZALEZ"><h4>JAVIER ALCEDO GONZALEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GIL PACHECO"><h4>JOSE GIL PACHECO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE DIEGO BASALLOTE MARTIN"><h4>JOSE DIEGO BASALLOTE MARTIN</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL VALDES CANTILLO"><h4>MANUEL VALDES CANTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL JESUS UTRERA GARCIA"><h4>MANUEL JESUS UTRERA GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIGUEL QUIROS PAREJA"><h4>MIGUEL QUIROS PAREJA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO RODRIGUEZ MORENO"><h4>PABLO RODRIGUEZ MORENO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO JIMENEZ RAMOS"><h4>PABLO JIMENEZ RAMOS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON MORILLO SANCHEZ"><h4>RAMON MORILLO SANCHEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RODRIGO ROSADO GONZALEZ"><h4>RODRIGO ROSADO GONZALEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TOMAS RAMIREZ JIMENEZ"><h4>TOMAS RAMIREZ JIMENEZ</h4></div>
+                        </div>
+                    </div>
+
+                    <!-- Infantil Femenino -->
+                    <div class="team-entry" data-category="infantil-femenino">
+                        <h3 class="team-name">Infantil Femenino</h3>
+                        <h5>Equipo: LA CHANCA BALONMANO BARBATE</h5>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AFRICA DE LA ROSA ALVARADO"><h4>AFRICA DE LA ROSA ALVARADO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AISHA VARO DIOUCK"><h4>AISHA VARO DIOUCK</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALICIA MUÑOZ LOPEZ"><h4>ALICIA MUÑOZ LOPEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN BERNAL GARCIA"><h4>CARMEN BERNAL GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CLAUDIA TIRADO RIVERA"><h4>CLAUDIA TIRADO RIVERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA VARO BERNAL"><h4>ELENA VARO BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FATIMA CARAVACA BERNAL"><h4>FATIMA CARAVACA BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCESCA CROCI ORTEGA"><h4>FRANCESCA CROCI ORTEGA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LOLA CID OLIVA"><h4>LOLA CID OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO MUÑOZ"><h4>MARIA VARO MUÑOZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA ANTONIA DE LA CRUZ LIGERO"><h4>MARIA ANTONIA DE LA CRUZ LIGERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA JESUS OLIVA CORRALES"><h4>MARIA JESUS OLIVA CORRALES</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NATALIA VALDES BRAZA"><h4>NATALIA VALDES BRAZA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSA GOMEZ DOMINGUEZ"><h4>ROSA GOMEZ DOMINGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SARA FERNANDEZ BERNAL"><h4>SARA FERNANDEZ BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TERE SANCHEZ BERNAL"><h4>TERE SANCHEZ BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de VALERIA YOLANDA GARCIA MARQUEZ"><h4>VALERIA YOLANDA GARCIA MARQUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ZAMARA NAVARRO RODRIGUEZ"><h4>ZAMARA NAVARRO RODRIGUEZ</h4></div>
+                        </div>
+                        <h5 style="margin-top: 1.5rem;">Equipo: BALONMANO BARBATE PROMESAS</h5>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AMAIA GIL MARIN"><h4>AMAIA GIL MARIN</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ARANTXA DE GOMAR LARA"><h4>ARANTXA DE GOMAR LARA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA RODRIGUEZ CASTILLO"><h4>CARLA RODRIGUEZ CASTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA GONZALEZ SANTIAGO"><h4>CARLA GONZALEZ SANTIAGO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN BARRIENTOS GALINDO"><h4>CARMEN BARRIENTOS GALINDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CORRALES VARO"><h4>CARMEN CORRALES VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CRISTINA SANCHEZ BEZA"><h4>CRISTINA SANCHEZ BEZA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de IDAYRA ANGULO AGUILAR"><h4>IDAYRA ANGULO AGUILAR</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA VELAZQUEZ GARCIA"><h4>JULIA VELAZQUEZ GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LARA LOPEZ VILADOMS"><h4>LARA LOPEZ VILADOMS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LAURA VARO BRENES"><h4>LAURA VARO BRENES</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA HEREDIA MUÑOZ"><h4>LUCIA HEREDIA MUÑOZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA MORON TRUJILLO"><h4>LUCIA MORON TRUJILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARGARITA MARQUEZ HORCAJADAS"><h4>MARGARITA MARQUEZ HORCAJADAS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA GUERRERO ALCEDO"><h4>MARIA GUERRERO ALCEDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA DANIELA MELENDEZ TIRADO"><h4>MARIA DANIELA MELENDEZ TIRADO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIAM GUTIERREZ -RAVE TIRADO"><h4>MARIAM GUTIERREZ -RAVE TIRADO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA PEREZ REVUELTA"><h4>MARTA PEREZ REVUELTA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA MALIA RENDON"><h4>MARTA MALIA RENDON</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA ARAGON BARRIENTOS"><h4>PAULA ARAGON BARRIENTOS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MORENO MEDINA"><h4>PAULA MORENO MEDINA</h4></div>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
+        </div>
+
+        <div id="playa-view" class="view-content">
+            <section id="beach-teams-list" class="container">
+                <h2>Nuestros Equipos de Playa</h2>
+                <p style="text-align: center; margin-bottom: 2rem;">Filtra por categoría para ver los equipos y sus jugadores.</p>
+
+                <!-- Contenedor de Filtros -->
+                <div id="beach-team-filters" class="tabs-container">
+                    <button class="tab-button active" data-category="all">Todos</button>
+                    <button class="tab-button" data-category="alevin-femenino">Alevin femenino</button>
+                    <button class="tab-button" data-category="infantil-femenino-1">Infantil femenino 1</button>
+                    <button class="tab-button" data-category="infantil-femenino-2">infantil femenino 2</button>
+                    <button class="tab-button" data-category="infantil-masculino-1">infantil masculino 1</button>
+                    <button class="tab-button" data-category="infantil-masculino-2">infantil masculino 2</button>
+                    <button class="tab-button" data-category="cadete-femenino-1">Cadete femenino 1</button>
+                    <button class="tab-button" data-category="cadete-femenino-2">Cadete femenino 2</button>
+                    <button class="tab-button" data-category="cadete-masculino">Cadete masculino</button>
+                    <button class="tab-button" data-category="senior-femenino">Senior femenino</button>
+                    <button class="tab-button" data-category="senior-masculino-1">senior masculino 1</button>
+                    <button class="tab-button" data-category="senior-masculino-2">senior masculino 2</button>
+                </div>
+
+                <!-- Contenedor de Equipos -->
+                <div id="beach-teams-container">
+                    <!-- Alevin femenino -->
+                    <div class="team-entry" data-category="alevin-femenino">
+                        <h3 class="team-name">BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ADRIANA BARRIENTOS GUERRERO"><h4>ADRIANA BARRIENTOS GUERRERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA VEGA PACHECO"><h4>CARLA VEGA PACHECO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA RAMOS MORILLO"><h4>DANIELA RAMOS MORILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA DEL CARMEN ROSSI GIL"><h4>DANIELA DEL CARMEN ROSSI GIL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA BERNAL TRUJILLO"><h4>JULIA BERNAL TRUJILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA RECIO BENITEZ"><h4>LUCIA RECIO BENITEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA MONTERO JODA"><h4>MARIA MONTERO JODA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA MALIA FEU"><h4>MARIA MALIA FEU</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MAYRA VARO PACHECO"><h4>MAYRA VARO PACHECO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAOLA JIMENEZ DONCEL MORIANO"><h4>PAOLA JIMENEZ DONCEL MORIANO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SELIN SOFIA SAVAL TRAUTZ"><h4>SELIN SOFIA SAVAL TRAUTZ</h4></div>
+                        </div>
+                    </div>
+                    <!-- Infantil femenino 1 -->
+                    <div class="team-entry" data-category="infantil-femenino-1">
+                        <h3 class="team-name">LA CHANCA BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AFRICA DE LA ROSA ALVARADO"><h4>AFRICA DE LA ROSA ALVARADO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AISHA VARO DIOUCK"><h4>AISHA VARO DIOUCK</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALICIA MUÑOZ LOPEZ"><h4>ALICIA MUÑOZ LOPEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA VARO BERNAL"><h4>ELENA VARO BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FATIMA CARAVACA BERNAL"><h4>FATIMA CARAVACA BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCESCA CROCI ORTEGA"><h4>FRANCESCA CROCI ORTEGA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LOLA CID OLIVA"><h4>LOLA CID OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO MUÑOZ"><h4>MARIA VARO MUÑOZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA ANTONIA DE LA CRUZ LIGERO"><h4>MARIA ANTONIA DE LA CRUZ LIGERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSA GOMEZ DOMINGUEZ"><h4>ROSA GOMEZ DOMINGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SARA FERNANDEZ BERNAL"><h4>SARA FERNANDEZ BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SARA FONSECA PARRA"><h4>SARA FONSECA PARRA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TERE SANCHEZ BERNAL"><h4>TERE SANCHEZ BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de VALERIA YOLANDA GARCIA MARQUEZ"><h4>VALERIA YOLANDA GARCIA MARQUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ZAMARA NAVARRO RODRIGUEZ"><h4>ZAMARA NAVARRO RODRIGUEZ</h4></div>
+                        </div>
+                    </div>
+                    <!-- infantil femenino 2 -->
+                    <div class="team-entry" data-category="infantil-femenino-2">
+                        <h3 class="team-name">BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ARANTXA DE GOMAR LARA"><h4>ARANTXA DE GOMAR LARA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARLA RODRIGUEZ CASTILLO"><h4>CARLA RODRIGUEZ CASTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN BARRIENTOS GALINDO"><h4>CARMEN BARRIENTOS GALINDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CORRALES VARO"><h4>CARMEN CORRALES VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CRISTINA SANCHEZ BEZA"><h4>CRISTINA SANCHEZ BEZA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de IDAYRA ANGULO AGUILAR"><h4>IDAYRA ANGULO AGUILAR</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JULIA VELAZQUEZ GARCIA"><h4>JULIA VELAZQUEZ GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LARA LOPEZ VILADOMS"><h4>LARA LOPEZ VILADOMS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA MORON TRUJILLO"><h4>LUCIA MORON TRUJILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARGARITA MARQUEZ HORCAJADAS"><h4>MARGARITA MARQUEZ HORCAJADAS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA GUERRERO ALCEDO"><h4>MARIA GUERRERO ALCEDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA MALIA RENDON"><h4>MARTA MALIA RENDON</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA PEREZ REVUELTA"><h4>MARTA PEREZ REVUELTA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA ARAGON BARRIENTOS"><h4>PAULA ARAGON BARRIENTOS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MORENO MEDINA"><h4>PAULA MORENO MEDINA</h4></div>
+                        </div>
+                    </div>
+                    <!-- infantil maculino 1 -->
+                    <div class="team-entry" data-category="infantil-masculino-1">
+                        <h3 class="team-name">BALONMANO BARBATE PROMESAS</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO GILABERT ROMERO"><h4>DARIO GILABERT ROMERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GONZALO GUTIERREZ RUIZ"><h4>GONZALO GUTIERREZ RUIZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JAVIER ALCEDO GONZALEZ"><h4>JAVIER ALCEDO GONZALEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE DIEGO BASALLOTE MARTIN"><h4>JOSE DIEGO BASALLOTE MARTIN</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL JESUS UTRERA GARCIA"><h4>MANUEL JESUS UTRERA GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIGUEL VILLAR MARTINEZ"><h4>MIGUEL VILLAR MARTINEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIGUEL QUIROS PAREJA"><h4>MIGUEL QUIROS PAREJA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO RODRIGUEZ MORENO"><h4>PABLO RODRIGUEZ MORENO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON MORILLO SANCHEZ"><h4>RAMON MORILLO SANCHEZ</h4></div>
+                        </div>
+                    </div>
+                    <!-- infantil masculino 2 -->
+                    <div class="team-entry" data-category="infantil-masculino-2">
+                        <h3 class="team-name">SALAZONES LA CHANCA BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ADRIAN TOCINO MARTIN"><h4>ADRIAN TOCINO MARTIN</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALBERTO SANCHEZ ARAGON"><h4>ALBERTO SANCHEZ ARAGON</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO LOPEZ JIMENEZ"><h4>ALEJANDRO LOPEZ JIMENEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL LEWERENZ LOSADA"><h4>EZEQUIEL LEWERENZ LOSADA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER SANCHEZ CANTILLO"><h4>FRANCISCO JAVIER SANCHEZ CANTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JOSE MUÑOZ ALONSO"><h4>FRANCISCO JOSE MUÑOZ ALONSO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GIL PACHECO"><h4>JOSE GIL PACHECO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL VALDES CANTILLO"><h4>MANUEL VALDES CANTILLO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RODRIGO ROSADO GONZALEZ"><h4>RODRIGO ROSADO GONZALEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TOMAS RAMIREZ JIMENEZ"><h4>TOMAS RAMIREZ JIMENEZ</h4></div>
+                        </div>
+                    </div>
+                    <!-- Cadete femenino 1 -->
+                    <div class="team-entry" data-category="cadete-femenino-1">
+                        <h3 class="team-name">BALONMANO BARBATE CAD FEM PROM</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRA GONZALEZ MALIA"><h4>ALEJANDRA GONZALEZ MALIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GONZALEZ PICAZO"><h4>CARMEN GONZALEZ PICAZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN MALIA CRESPO"><h4>CARMEN MALIA CRESPO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN CARO RELINQUE"><h4>CARMEN CARO RELINQUE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CELIA BLANCO DENIA"><h4>CELIA BLANCO DENIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DANIELA CORTEJOSA VARO"><h4>DANIELA CORTEJOSA VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ELENA AREVALO RIVERA"><h4>ELENA AREVALO RIVERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EVA TIRADO CLA"><h4>EVA TIRADO CLA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GEMA GUZMAN AMBITE"><h4>GEMA GUZMAN AMBITE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA RUBIO POZO"><h4>LUCIA RUBIO POZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA ALBA CORTEJOSA"><h4>LUCIA ALBA CORTEJOSA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PATRICIA MALIA JODAR"><h4>PATRICIA MALIA JODAR</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAULA MONCAYO RODRIGUEZ"><h4>PAULA MONCAYO RODRIGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSARIO LOPEZ NUÑEZ"><h4>ROSARIO LOPEZ NUÑEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SOFIA BRAVO GRAÑA"><h4>SOFIA BRAVO GRAÑA</h4></div>
+                        </div>
+                    </div>
+                    <!-- Cadete femenino 2 -->
+                    <div class="team-entry" data-category="cadete-femenino-2">
+                        <h3 class="team-name">LA CHANCA BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN GIL GILIBERT"><h4>CARMEN GIL GILIBERT</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CLAUDIA CUENCA SANCHEZ DE LA CAMPA"><h4>CLAUDIA CUENCA SANCHEZ DE LA CAMPA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCIA TAMAYO MANZORRO"><h4>LUCIA TAMAYO MANZORRO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA RAMOS CHIRINO"><h4>MARIA RAMOS CHIRINO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA VARO CABALLERO"><h4>MARIA VARO CABALLERO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIRIAM GONZALEZ TAMAYO"><h4>MIRIAM GONZALEZ TAMAYO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NORA DIEGO VENEGAS"><h4>NORA DIEGO VENEGAS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de NORA LABANDON BERNAL"><h4>NORA LABANDON BERNAL</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PAOLA CORRALES VARO"><h4>PAOLA CORRALES VARO</h4></div>
+                        </div>
+                    </div>
+                    <!-- Cadete masculino -->
+                    <div class="team-entry" data-category="cadete-masculino">
+                        <h3 class="team-name">SALAZONES LA CHANCA BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO MEDINA BARRERA"><h4>ALEJANDRO MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO NUÑEZ CARAMAZANA"><h4>ALEJANDRO NUÑEZ CARAMAZANA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALI VERSACI DIAZ"><h4>ALI VERSACI DIAZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALONSO OLIVA SANCHEZ"><h4>ALONSO OLIVA SANCHEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALVARO RAMIREZ PAREJA"><h4>ALVARO RAMIREZ PAREJA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ANTONIO CHAMORRO ALBA"><h4>ANTONIO CHAMORRO ALBA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ANTONIO VILLAR MARTINEZ"><h4>ANTONIO VILLAR MARTINEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DARIO MEDINA BARRERA"><h4>DARIO MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de EZEQUIEL GRAÑA SOUZA"><h4>EZEQUIEL GRAÑA SOUZA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ALBERTO GOMEZ DOMINGUEZ"><h4>JOSE ALBERTO GOMEZ DOMINGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE ANGEL POZO NARVAEZ"><h4>JOSE ANGEL POZO NARVAEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE MANUEL PAREJA DAVILA"><h4>JOSE MANUEL PAREJA DAVILA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MANUEL ANTONIO RELINQUE CAMACHO"><h4>MANUEL ANTONIO RELINQUE CAMACHO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PEDRO LARA OLIVA"><h4>PEDRO LARA OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RAMON DEL POZO ROSSI"><h4>RAMON DEL POZO ROSSI</h4></div>
+                        </div>
+                    </div>
+                    <!-- Senior femenino -->
+                    <div class="team-entry" data-category="senior-femenino">
+                        <h3 class="team-name">BM BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ANA CHICA MARTIN"><h4>ANA CHICA MARTIN</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de CARMEN RAMOS CHIRINO"><h4>CARMEN RAMOS CHIRINO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JACQUELINE YAZMIN FONSECA PARRA"><h4>JACQUELINE YAZMIN FONSECA PARRA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de LUCI RAMIREZ JIMENEZ"><h4>LUCI RAMIREZ JIMENEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MACARENA LOZANO TOVAR"><h4>MACARENA LOZANO TOVAR</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA CRESPO GALLARDO"><h4>MARIA CRESPO GALLARDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARIA LUZ BERNAL OLIVA"><h4>MARIA LUZ BERNAL OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTA BENITEZ OLIVA"><h4>MARTA BENITEZ OLIVA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ROSARIO CABELLO ESTUDILLO"><h4>ROSARIO CABELLO ESTUDILLO</h4></div>
+                        </div>
+                    </div>
+                    <!-- senior masculino 1 -->
+                    <div class="team-entry" data-category="senior-masculino-1">
+                        <h3 class="team-name">SALAZONES LA CHANCA BM BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE"><h4>ALFREDO JOSE CASTILLO GOMEZ DE LA TORRE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DAVID GARRIDO LOPEZ"><h4>DAVID GARRIDO LOPEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DAVID JIMENEZ RODRIGUEZ"><h4>DAVID JIMENEZ RODRIGUEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DIEGO RELINQUE LEMOS"><h4>DIEGO RELINQUE LEMOS</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de DIEGO GONZALEZ PICAZO"><h4>DIEGO GONZALEZ PICAZO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER MANZORRO CRESPO"><h4>FRANCISCO JAVIER MANZORRO CRESPO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JAVIER SANCHEZ BARON"><h4>JAVIER SANCHEZ BARON</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JOSE GOMEZ LOPEZ"><h4>JOSE GOMEZ LOPEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MARTIN PACHECO CAZORLA"><h4>MARTIN PACHECO CAZORLA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de OSCAR RUIZ GARCIA"><h4>OSCAR RUIZ GARCIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de PABLO VALLEJO HERNANDEZ"><h4>PABLO VALLEJO HERNANDEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SEBASTIAN CARDOSO TRAUCA"><h4>SEBASTIAN CARDOSO TRAUCA</h4></div>
+                        </div>
+                    </div>
+                    <!-- senior masculino 2 -->
+                    <div class="team-entry" data-category="senior-masculino-2">
+                        <h3 class="team-name">BALONMANO BARBATE</h3>
+                        <div class="player-grid">
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de AARON MEDINA BARRERA"><h4>AARON MEDINA BARRERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ADRIAN GUZMAN AMBITE"><h4>ADRIAN GUZMAN AMBITE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de ALEJANDRO GUERRERO VARO"><h4>ALEJANDRO GUERRERO VARO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de BRIAN HERNANDEZ MALIA"><h4>BRIAN HERNANDEZ MALIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO VIDAL MATEO"><h4>FRANCISCO VIDAL MATEO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO JAVIER GUERRERO SUAREZ"><h4>FRANCISCO JAVIER GUERRERO SUAREZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de FRANCISCO MANUEL CLA MARTINEZ"><h4>FRANCISCO MANUEL CLA MARTINEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de GONZALO VERDUGO MARTINEZ"><h4>GONZALO VERDUGO MARTINEZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JESUS CABELLO MALIA"><h4>JESUS CABELLO MALIA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de JUAN JOSE CANALES CIFUENTES"><h4>JUAN JOSE CANALES CIFUENTES</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de MIGUEL MARISCAL PEREZ"><h4>MIGUEL MARISCAL PEREZ</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de OSCAR PEREZ SEQUERA"><h4>OSCAR PEREZ SEQUERA</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de RICARDO CRESPO GALLARDO"><h4>RICARDO CRESPO GALLARDO</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de SAMUEL VARO AMBITE"><h4>SAMUEL VARO AMBITE</h4></div>
+                            <div class="player-card"><img src="https://via.placeholder.com/150" alt="Foto de TOMAS JESUS RAMIREZ TIRADO"><h4>TOMAS JESUS RAMIREZ TIRADO</h4></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
         </section>
     </main>
 

--- a/galerias.html
+++ b/galerias.html
@@ -16,14 +16,21 @@
     <header id="main-header">
         <div class="header-container">
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>

--- a/index.html
+++ b/index.html
@@ -26,16 +26,23 @@
         <div class="header-container">
             <!-- Logo del Club Balonmano Barbate -->
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
 
             <!-- Menú de Navegación -->
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>

--- a/js/script.js
+++ b/js/script.js
@@ -100,23 +100,69 @@ document.addEventListener('DOMContentLoaded', () => {
 
     /**
      * ------------------------------------------------
-     * 4. LÓGICA DE ACORDEÓN (PÁGINA DE EQUIPOS)
+     * 4. FILTRADO DE EQUIPOS (PÁGINA DE EQUIPOS)
      * ------------------------------------------------
-     * Controla el despliegue de las plantillas de jugadores.
+     * Encapsula la lógica de filtrado para que sea reutilizable.
      */
-    const accordions = document.querySelectorAll('.accordion');
+    const setupTeamFiltering = (filterContainerId, teamsContainerId) => {
+        const filterButtons = document.querySelectorAll(`#${filterContainerId} .tab-button`);
+        const teamEntries = document.querySelectorAll(`#${teamsContainerId} .team-entry`);
 
-    accordions.forEach(accordion => {
-        accordion.addEventListener('click', function() {
-            this.classList.toggle('active');
-            const panel = this.nextElementSibling;
-            if (panel.style.maxHeight) {
-                panel.style.maxHeight = null;
+        if (filterButtons.length > 0 && teamEntries.length > 0) {
+            filterButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    // Gestionar la clase 'active' en los botones
+                    filterButtons.forEach(btn => btn.classList.remove('active'));
+                    this.classList.add('active');
+
+                    const category = this.getAttribute('data-category');
+
+                    // Mostrar u ocultar equipos
+                    teamEntries.forEach(entry => {
+                        const entryCategory = entry.getAttribute('data-category');
+                        if (category === 'all' || entryCategory === category) {
+                            entry.classList.remove('hidden');
+                        } else {
+                            entry.classList.add('hidden');
+                        }
+                    });
+                });
+            });
+        }
+    };
+
+    // Inicializar filtrado para equipos de pista
+    setupTeamFiltering('team-filters', 'teams-container');
+
+    // Inicializar filtrado para equipos de playa
+    setupTeamFiltering('beach-team-filters', 'beach-teams-container');
+
+    /**
+     * ------------------------------------------------
+     * 5. GESTIÓN DE VISTAS (PÁGINA DE EQUIPOS)
+     * ------------------------------------------------
+     * Muestra la vista correcta ('Pista' or 'Playa') basado en el parámetro URL.
+     */
+    const handleTeamView = () => {
+        const params = new URLSearchParams(window.location.search);
+        const view = params.get('view') || 'pista'; // Default to 'pista'
+
+        const pistaView = document.getElementById('pista-view');
+        const playaView = document.getElementById('playa-view');
+
+        if (pistaView && playaView) {
+            if (view === 'playa') {
+                pistaView.classList.remove('active');
+                playaView.classList.add('active');
             } else {
-                panel.style.maxHeight = panel.scrollHeight + "px";
+                pistaView.classList.add('active');
+                playaView.classList.remove('active');
             }
-        });
-    });
+        }
+    };
 
-
+    // Si estamos en la página de equipos, gestionar la vista
+    if (document.getElementById('pista-view') || document.getElementById('playa-view')) {
+        handleTeamView();
+    }
 });

--- a/noticias.html
+++ b/noticias.html
@@ -16,14 +16,21 @@
     <header id="main-header">
         <div class="header-container">
             <a href="index.html" class="logo">
-                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px; border-radius: 50%;">
+                <img src="http://balonmano.isquad.es/images/afiliacion_clubs/100165/square_6467683739316b316233.jpg" alt="Logo del Club Balonmano Barbate" style="height: 60px;">
             </a>
             <nav id="main-nav" aria-label="Menú principal">
                 <ul class="nav-list">
                     <li><a href="club.html">Club</a></li>
-                    <li><a href="equipos.html">Equipos</a></li>
+                    <li class="dropdown">
+                        <a href="equipos.html" class="dropdown-toggle">Equipos</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="equipos.html?view=pista">Pista</a></li>
+                            <li><a href="equipos.html?view=playa">Playa</a></li>
+                        </ul>
+                    </li>
                     <li><a href="noticias.html">Noticias</a></li>
                     <li><a href="galerias.html">Galerías</a></li>
+                    <li><a href="entrenadores.html">Entrenadores</a></li>
                     <li><a href="contacto.html">Contacto</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
I've implemented your request to change the team navigation into a dropdown menu for the "Pista" and "Playa" teams. I also addressed your feedback to remove the circular styling from the club logo.

- I updated the main navigation bar in all HTML files. The "Equipos" link is now a dropdown.
- I added CSS to style the new dropdown menu.
- I refactored `equipos.html` to show either the "Pista" or "Playa" section based on a URL parameter (`?view=...`).
- I added JavaScript to handle the URL parameter logic on page load.
- I removed the inline style for `border-radius` from the club logo on all pages.